### PR TITLE
chore: standardize make targets and checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
-.PHONY: install dev test lint format check docker-build docker-run
+.PHONY: help install dev test lint format format-check typecheck contract-check check docker-build docker-run
+
+help:
+	@echo "richmiles.xyz"
+	@echo ""
+	@echo "Commands:"
+	@echo "  make install         Install dependencies"
+	@echo "  make dev             Run local container on :8000"
+	@echo "  make lint            Run ESLint"
+	@echo "  make format          Check Prettier formatting"
+	@echo "  make format-check    Check Prettier formatting"
+	@echo "  make typecheck       Run TypeScript typecheck"
+	@echo "  make contract-check  Verify fleet contract"
+	@echo "  make check           Run lint + format-check + typecheck + contract-check"
+	@echo "  make docker-build    Build production image"
 
 install:
 	@npm install
@@ -16,9 +30,19 @@ lint:
 format:
 	@npm run format
 
-check:
+format-check: format
+
+typecheck:
+	@npx tsc -b
+
+contract-check:
 	@python3 scripts/check_contract.py
-	@echo "Contract check ok. Run 'make lint' and 'make docker-build' for a deeper check."
+
+check:
+	@$(MAKE) lint
+	@$(MAKE) format-check
+	@$(MAKE) typecheck
+	@$(MAKE) contract-check
 
 docker-build:
 	@docker build -t ghcr.io/richmiles/richmiles-xyz-app:latest .


### PR DESCRIPTION
Standardize Makefile targets by adding help/format-check/typecheck/contract-check and make `check` run lint + format-check + typecheck + contract-check.
