### PR TITLE
fix: platform patterns audit — ProjectCarousel error handling

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -33,13 +33,28 @@ function formatDeploy(iso: string | null): string {
 
 export default function ProjectCarousel() {
   const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [current, setCurrent] = useState(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const touchStartRef = useRef<number | null>(null)
   const count = projects.length
 
   useEffect(() => {
-    fetchProjects().then(setProjects)
+    let active = true
+    fetchProjects()
+      .then((data) => {
+        if (active) setProjects(data)
+      })
+      .catch((err) => {
+        if (active) setError((err as Error).message)
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
   }, [])
 
   const goTo = useCallback(
@@ -100,7 +115,20 @@ export default function ProjectCarousel() {
     touchStartRef.current = null
   }
 
-  if (projects.length === 0) {
+  if (error) {
+    return (
+      <section className="projects" id="projects">
+        <div className="container">
+          <h2 className="section-title">Projects</h2>
+          <p style={{ textAlign: 'center', color: 'var(--text-muted)' }}>
+            Failed to load projects: {error}
+          </p>
+        </div>
+      </section>
+    )
+  }
+
+  if (loading || projects.length === 0) {
     return (
       <section className="projects" id="projects">
         <div className="container">


### PR DESCRIPTION
## Summary
- Add explicit `loading` and `error` states to ProjectCarousel
- Add `active` flag cleanup in useEffect to prevent state updates after unmount
- Per PLATFORM_PATTERNS.md §13 component patterns

## Test plan
- [x] `make check` passes (lint, format, typecheck, 28 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)