### PR TITLE
chore: drop swarm.sparkswarm.com, use sparkswarm.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # richmiles.xyz runtime env vars
 SPARK_SWARM_API_KEY=your-api-key-here
-SPARK_SWARM_API_URL=https://swarm.sparkswarm.com/api/v1
+SPARK_SWARM_API_URL=https://sparkswarm.com/api/v1

--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -40,7 +40,7 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/stage') && github.actor == github.repository_owner)
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
     env:
-      SPARK_SWARM_API_URL: https://swarm.sparkswarm.com/api/v1
+      SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
     steps:
       - name: Resolve PR ref (issue_comment only)
         if: ${{ github.event_name == 'issue_comment' }}

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -28,7 +28,7 @@ jobs:
   deploy:
     runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
     env:
-      SPARK_SWARM_API_URL: https://swarm.sparkswarm.com/api/v1
+      SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
       PROD_HOST: 159.65.241.127
     steps:
       - name: Checkout (target ref)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Vite + React + TypeScript portfolio site with a FastAPI backend. Single uvicorn 
 ## Environment variables
 
 - `SPARK_SWARM_API_KEY` — required for fetching project data from Spark Swarm
-- `SPARK_SWARM_API_URL` — defaults to `https://swarm.sparkswarm.com/api/v1`
+- `SPARK_SWARM_API_URL` — defaults to `https://sparkswarm.com/api/v1`
 
 ## Local dev
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -6,7 +6,7 @@ class Settings(BaseSettings):
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     environment: str = "dev"
-    spark_swarm_api_url: str = "https://swarm.sparkswarm.com/api/v1"
+    spark_swarm_api_url: str = "https://sparkswarm.com/api/v1"
     spark_swarm_api_key: str | None = None
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -54,7 +54,7 @@ class PortfolioApiTests(unittest.TestCase):
                         "slug": "spark-swarm",
                         "name": "Spark Swarm",
                         "description": "Live control plane",
-                        "domain": "swarm.sparkswarm.com",
+                        "domain": "sparkswarm.com",
                         "stage": "building",
                         "health": "healthy",
                         "last_deploy_at": "2026-03-13T12:00:00",
@@ -82,7 +82,7 @@ class PortfolioApiTests(unittest.TestCase):
                     },
                 ]
             },
-            request=httpx.Request("GET", "https://swarm.sparkswarm.com/api/v1/sparks"),
+            request=httpx.Request("GET", "https://sparkswarm.com/api/v1/sparks"),
         )
         mock_client = AsyncMock()
         mock_client.get.return_value = upstream_response

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -26,7 +26,7 @@ const FALLBACK: Project[] = [
     title: 'Spark Swarm',
     description:
       'Dashboard for managing projects, secrets, deployments, and fleet health across a multi-service platform.',
-    domain: 'swarm.sparkswarm.com',
+    domain: 'sparkswarm.com',
     stage: 'building',
     health: 'healthy',
     last_deploy_at: null,


### PR DESCRIPTION
## Summary
- Replace `swarm.sparkswarm.com` references with the canonical `sparkswarm.com` domain. The legacy subdomain vhost is being retired in `platform-infra`.
- Coordinated cleanup; sibling PRs in `spark-swarm`, `platform-infra`, and other fleet repos handle their respective surfaces.

## Test plan
- [ ] No surprising matches remain (`grep -r swarm.sparkswarm.com .`)
- [ ] Will be exercised end-to-end once the prod rollout in `platform-infra` lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)