### PR TITLE
chore: ship runners-default + add pre-commit + bump actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - name: Compute tags
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
   check:
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install (web)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   check:
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -38,7 +38,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/stage') && github.actor == github.repository_owner)
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     env:
       SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
     steps:

--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -64,7 +64,7 @@ jobs:
           echo "ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (target ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.ref || steps.manual.outputs.ref }}
 
@@ -102,7 +102,7 @@ jobs:
           token: ${{ secrets.DO_API_TOKEN }}
 
       - name: Checkout Spark Swarm runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: miles-automation/spark-swarm
           path: spark-swarm
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     env:
       SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
       PROD_HOST: 159.65.241.127

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -32,7 +32,7 @@ jobs:
       PROD_HOST: 159.65.241.127
     steps:
       - name: Checkout (target ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref }}
 
@@ -62,7 +62,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/richmiles-xyz-app:${{ steps.meta.outputs.tag }}
 
       - name: Checkout Spark Swarm runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: miles-automation/spark-swarm
           path: spark-swarm
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        types_or: [python, pyi]
+      - id: ruff-format
+        types_or: [python, pyi]


### PR DESCRIPTION
## Summary

Three small CI hygiene changes batched into one PR:

1. **Ship the previously-unpushed local main commit** `0a51953 ci: default workflow runners to ubuntu-latest` (Apr 27 2026). This was committed locally but never pushed; it makes `ubuntu-latest` the default runner target for all four workflows (with the self-hosted canary still selectable via `workflow_dispatch`).
2. **Add `.pre-commit-config.yaml`** (ruff v0.8.0 + ruff-format) so this repo matches the sibling platform repos.
3. **Bump GitHub Actions to Node 24-ready majors** ahead of the forced cutover:
   - `actions/checkout` v4 → v6
   - `actions/setup-python` v5 → v6
   - `actions/setup-node` v4 → v6
   - `astral-sh/setup-uv` v4 → v7 (none currently used in this repo, but covered by the fleet-wide sweep policy)

### Why now

GitHub is forcing all `actions/*` runners onto Node 24 on **2026-06-16**, and Node 20 is removed on **2026-09-16**. The v4/v5 majors still run on Node 20 and will start failing after the cutover. Doing the bump now is cheap, deterministic, and avoids a fire drill in three weeks.

This PR is part of a fleet-wide sweep across the platform repos (sibling PRs on `for-whenever`, `in-the-event-of-my-death`, and `noodle`).

## Test plan

- [ ] CI workflow passes on this PR (validates the `actions/checkout@v6`, `actions/setup-python@v6`, `actions/setup-node@v6` bumps end to end).
- [ ] Build workflow produces a `pr-<n>-<sha>` image successfully.
- [ ] After merge, the next `Ephemeral Staging` and `Promote to Production` manual runs succeed against the bumped action versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)